### PR TITLE
Add clean architecture boilerplate

### DIFF
--- a/domain/model/list.go
+++ b/domain/model/list.go
@@ -1,0 +1,21 @@
+package model
+
+type ListDefinition struct {
+	List []List `json:"list"`
+}
+
+// Struct to unmarshal the Urban dictionary response of definitions based on a term
+// API For more infomation: https://rapidapi.com/community/api/urban-dictionary/
+type List struct {
+	Definition  string   `json:"definition"`
+	Permalink   string   `json:"permalink"`
+	ThumbsUp    int64    `json:"thumbs_up"`
+	SoundUrls   []string `json:"sound_urls"`
+	Author      string   `json:"author"`
+	Word        string   `json:"word"`
+	Defid       int64    `json:"defid"`
+	CurrentVote string   `json:"current_vote"`
+	WrittenOn   string   `json:"written_on"`
+	Example     string   `json:"example"`
+	ThumbsDown  int64    `json:"thumbs_down"`
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/OrlandoRomo/academy-go-q32021
+
+go 1.17
+
+require github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/infrastructure/router/router.go
+++ b/infrastructure/router/router.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func NewRouter() *mux.Router {
+	router := mux.NewRouter()
+	router = router.PathPrefix("/api/v1/").Subrouter()
+
+	router.HandleFunc("/definitions/", func(rw http.ResponseWriter, r *http.Request) {}).
+		Queries("term", "{term}").
+		Methods(http.MethodGet)
+
+	router.HandleFunc("/definitions/csv/", func(rw http.ResponseWriter, r *http.Request) {}).
+		Queries("concurrent", "{concurrent:^(true|false)}").
+		Methods(http.MethodGet)
+	return mux.NewRouter()
+}

--- a/interface/controllers/app_controller.go
+++ b/interface/controllers/app_controller.go
@@ -1,0 +1,5 @@
+package controllers
+
+type AppController interface {
+	ListController
+}

--- a/interface/controllers/list_controller.go
+++ b/interface/controllers/list_controller.go
@@ -1,0 +1,15 @@
+package controllers
+
+import "github.com/OrlandoRomo/academy-go-q32021/usercase/interactor"
+
+type listController struct {
+	listInteractor interactor.ListInteractor
+}
+
+type ListController interface {
+	GetDefinitions() error
+}
+
+func (l *listController) GetDefinitions() error {
+	return nil
+}

--- a/interface/presenters/list_presenter.go
+++ b/interface/presenters/list_presenter.go
@@ -1,0 +1,1 @@
+package presenters

--- a/main.go
+++ b/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/registry/list_registry.go
+++ b/registry/list_registry.go
@@ -1,0 +1,1 @@
+package registry

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,1 @@
+package registry

--- a/usercase/interactor/list_interactor.go
+++ b/usercase/interactor/list_interactor.go
@@ -1,0 +1,20 @@
+package interactor
+
+import (
+	"github.com/OrlandoRomo/academy-go-q32021/domain/model"
+	"github.com/OrlandoRomo/academy-go-q32021/usercase/presenter"
+	"github.com/OrlandoRomo/academy-go-q32021/usercase/repository"
+)
+
+type listInteractor struct {
+	ListRepository repository.ListRepository
+	ListPresenter  presenter.ListPresenter
+}
+
+type ListInteractor interface {
+	Get(term string) ([]*model.List, error)
+}
+
+func NewListInteractor(r repository.ListRepository, p presenter.ListPresenter) *listInteractor {
+	return &listInteractor{r, p}
+}

--- a/usercase/presenter/list_presenter.go
+++ b/usercase/presenter/list_presenter.go
@@ -1,0 +1,7 @@
+package presenter
+
+import "github.com/OrlandoRomo/academy-go-q32021/domain/model"
+
+type ListPresenter interface {
+	ResponseList(term *string) []*model.List
+}

--- a/usercase/repository/list_repository.go
+++ b/usercase/repository/list_repository.go
@@ -1,0 +1,7 @@
+package repository
+
+import "github.com/OrlandoRomo/academy-go-q32021/domain/model"
+
+type ListRepository interface {
+	FindDefinitionsList(l []*model.List) ([]*model.List, error)
+}


### PR DESCRIPTION
Details for the first deliverable: https://classroom.google.com/c/Mzk0MDUzNTg0MjQz/a/Mzk0MDUzNTg0Mjc1/details

#### Changes
- Init go modules
- Defined structs for the [Urban dictionary API](https://rapidapi.com/community/api/urban-dictionary/)
- Created packages following the clean architecture.
- Defined two new routes
  1. `/definitions/`
  2. `/definitions/csv/`
- Created urban dictionary controller, interactor, presenter, repository